### PR TITLE
[starter-ui] cleanup outdated fix

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2369,8 +2369,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       });
 
       const fitsWin = this.filterBar.getVals(DropDownColumn.MISC).some(misc => {
-        if (container.species.speciesId < 10) {
-        }
         if (misc.val === "WIN" && misc.state === DropDownState.ON) {
           return isWin;
         } else if (misc.val === "WIN" && misc.state === DropDownState.EXCLUDE) {
@@ -2913,21 +2911,19 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       const dexEntry = this.scene.gameData.dexData[species.speciesId];
       const abilityAttr = this.scene.gameData.starterData[species.speciesId].abilityAttr;
 
-      const isCaught = this.scene.gameData.dexData[species.speciesId]?.caughtAttr || BigInt(0);
-      const isVariant3Caught = !!(isCaught & DexAttr.VARIANT_3);
-      const isVariant2Caught = !!(isCaught & DexAttr.VARIANT_2);
-      const isDefaultVariantCaught = !!(isCaught & DexAttr.DEFAULT_VARIANT);
-      const isVariantCaught = !!(isCaught & DexAttr.SHINY);
-      const isMaleCaught = !!(isCaught & DexAttr.MALE);
-      const isFemaleCaught = !!(isCaught & DexAttr.FEMALE);
-
-      const starterAttributes = this.starterPreferences[species.speciesId];
-
-      const props = this.scene.gameData.getSpeciesDexAttrProps(species, this.getCurrentDexProps(species.speciesId));
-      const defaultAbilityIndex = this.scene.gameData.getStarterSpeciesDefaultAbilityIndex(species);
-      const defaultNature = this.scene.gameData.getSpeciesDefaultNature(species);
+      const caughtAttr = this.scene.gameData.dexData[species.speciesId]?.caughtAttr || BigInt(0);
+      const isVariant3Caught = !!(caughtAttr & DexAttr.VARIANT_3);
+      const isVariant2Caught = !!(caughtAttr & DexAttr.VARIANT_2);
+      const isVariantCaught = !!(caughtAttr & DexAttr.SHINY);
+      const isNonShinyCaught = !!(caughtAttr & DexAttr.NON_SHINY);
+      const isMaleCaught = !!(caughtAttr & DexAttr.MALE);
+      const isFemaleCaught = !!(caughtAttr & DexAttr.FEMALE);
 
       if (!dexEntry.caughtAttr) {
+        const props = this.scene.gameData.getSpeciesDexAttrProps(species, this.getCurrentDexProps(species.speciesId));
+        const defaultAbilityIndex = this.scene.gameData.getStarterSpeciesDefaultAbilityIndex(species);
+        const defaultNature = this.scene.gameData.getSpeciesDefaultNature(species);
+
         if (shiny === undefined || shiny !== props.shiny) {
           shiny = props.shiny;
         }
@@ -2945,83 +2941,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         }
         if (natureIndex === undefined || natureIndex !== defaultNature) {
           natureIndex = defaultNature;
-        }
-      } else {
-        // compare current shiny, formIndex, female, variant, abilityIndex, natureIndex with the caught ones
-        // if the current ones are not caught, we need to find the next caught ones
-        if (shiny) {
-          if (!(isVariantCaught || isVariant2Caught || isVariant3Caught)) {
-            shiny = false;
-            starterAttributes.shiny = false;
-            variant = 0;
-            starterAttributes.variant = 0;
-          } else {
-            shiny = true;
-            starterAttributes.shiny = true;
-            if (variant === 0 && !isDefaultVariantCaught) {
-              if (isVariant2Caught) {
-                variant = 1;
-                starterAttributes.variant = 1;
-              } else if (isVariant3Caught) {
-                variant = 2;
-                starterAttributes.variant = 2;
-              } else {
-                variant = 0;
-                starterAttributes.variant = 0;
-              }
-            } else if (variant === 1 && !isVariant2Caught) {
-              if (isVariantCaught) {
-                variant = 0;
-                starterAttributes.variant = 0;
-              } else if (isVariant3Caught) {
-                variant = 2;
-                starterAttributes.variant = 2;
-              } else {
-                variant = 0;
-                starterAttributes.variant = 0;
-              }
-            } else if (variant === 2 && !isVariant3Caught) {
-              if (isVariantCaught) {
-                variant = 0;
-                starterAttributes.variant = 0;
-              } else if (isVariant2Caught) {
-                variant = 1;
-                starterAttributes.variant = 1;
-              } else {
-                variant = 0;
-                starterAttributes.variant = 0;
-              }
-            }
-          }
-        }
-        if (female) {
-          if (!isFemaleCaught) {
-            female = false;
-            starterAttributes.female = false;
-          }
-        } else {
-          if (!isMaleCaught) {
-            female = true;
-            starterAttributes.female = true;
-          }
-        }
-
-        if (species.forms) {
-          const formCount = species.forms.length;
-          let newFormIndex = formIndex??0;
-          if (species.forms[newFormIndex]) {
-            const isValidForm = species.forms[newFormIndex].isStarterSelectable && dexEntry.caughtAttr & this.scene.gameData.getFormAttr(newFormIndex);
-            if (!isValidForm) {
-              do {
-                newFormIndex = (newFormIndex + 1) % formCount;
-                if (species.forms[newFormIndex].isStarterSelectable && dexEntry.caughtAttr & this.scene.gameData.getFormAttr(newFormIndex)) {
-                  break;
-                }
-              } while (newFormIndex !== props.formIndex);
-              formIndex = newFormIndex;
-              starterAttributes.form = formIndex;
-            }
-          }
         }
       }
 
@@ -3064,7 +2983,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           currentFilteredContainer.checkIconId(female, formIndex, shiny, variant);
         }
 
-        this.canCycleShiny = isVariantCaught || isVariant2Caught || isVariant3Caught;
+        this.canCycleShiny = isNonShinyCaught && (isVariantCaught || isVariant2Caught || isVariant3Caught);
         this.canCycleGender = isMaleCaught && isFemaleCaught;
         this.canCycleAbility = [ abilityAttr & AbilityAttr.ABILITY_1, (abilityAttr & AbilityAttr.ABILITY_2) && species.ability2, abilityAttr & AbilityAttr.ABILITY_HIDDEN ].filter(a => a).length > 1;
         this.canCycleForm = species.forms.filter(f => f.isStarterSelectable || !pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey))


### PR DESCRIPTION
this is not complete, but a first step to make sure I'm able to create a PR on your repo without needing to create a fork of it :p
So far I just fixed the canCycleShiny condition and reverted part of [the previous fixes](https://github.com/pagefaultgames/pokerogue/pull/3617/files) that are no longer needed with these changes

Things to test out for (normally this is all good, but I'm putting it here to help me keep track of everything):
- Shiny: Cases where shiny is unlocked but the non shiny pokemon was never caught. [Example file](https://discord.com/channels/1125469663833370665/1274463950867664956/1274465165785694259)
In this file there is a  shiny Magearna (tier1) and hisuian Sneasel (tier2) that fit this criteria. For them, the correct tier shiny should be shown by default, and we should not be able to pick the non shiny form
- Form: All Pokemon with multiple forms should not show the first form by default unless it's actually unlocked. This is easy to test on accounts that don't have Unown A unlocked. In the file above, the Magearna is also in this situation as the normal form is not unlocked, but the original one is. So this is the one that should be showing. Same with Zarude
- Gender: Pokemon with only female gender should show as such in the starter UI and should have the correct gender when starting the run (that second part was still broken after the hotfixes)