### PR TITLE
Switch to a different text window when testing dialogue

### DIFF
--- a/src/ui/battle-message-ui-handler.ts
+++ b/src/ui/battle-message-ui-handler.ts
@@ -21,6 +21,8 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
   public movesWindowContainer: Phaser.GameObjects.Container;
   public nameBoxContainer: Phaser.GameObjects.Container;
 
+  public readonly wordWrapWidth: number = 1780;
+
   constructor(scene: BattleScene) {
     super(scene, Mode.MESSAGE);
   }
@@ -63,7 +65,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
     const message = addTextObject(this.scene, 0, 0, "", TextStyle.MESSAGE, {
       maxLines: 2,
       wordWrap: {
-        width: 1780
+        width: this.wordWrapWidth
       }
     });
     messageContainer.add(message);
@@ -129,7 +131,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
 
     this.commandWindow.setVisible(false);
     this.movesWindowContainer.setVisible(false);
-    this.message.setWordWrapWidth(1780);
+    this.message.setWordWrapWidth(this.wordWrapWidth);
 
     return true;
   }


### PR DESCRIPTION
* exposed the word wrap width used by the BattleMessageUiHandler
* used it to set the word wrap width to be the same when testing dialog

video:
https://discord.com/channels/1125469663833370665/1277574059231805531/1277621293516328970