### PR TITLE
Cleanup FormUiHandler a little

### DIFF
--- a/src/ui/form-modal-ui-handler.ts
+++ b/src/ui/form-modal-ui-handler.ts
@@ -29,9 +29,6 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
     this.formLabels = [];
   }
 
-  // this function takes any args and uses it to make an array of InputFieldConfigs, which has extra support for the input text field
-  // It currently has support for a field's label, whether it's a password field, and whether the field should be read only, but by expanding the InputFieldConfig interface
-  // any extra details can be passed on to the field during creation
   /**
    * Get all information for each field to display in the modal
    * @returns array of {@linkcode InputFieldConfig}

--- a/src/ui/form-modal-ui-handler.ts
+++ b/src/ui/form-modal-ui-handler.ts
@@ -29,15 +29,17 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
     this.formLabels = [];
   }
 
-  abstract getFields(): string[];
-
   // this function takes any args and uses it to make an array of InputFieldConfigs, which has extra support for the input text field
   // It currently has support for a field's label, whether it's a password field, and whether the field should be read only, but by expanding the InputFieldConfig interface
   // any extra details can be passed on to the field during creation
-  abstract getInputFieldConfigs(args?: any): InputFieldConfigs[];
+  /**
+   * Get all information for each field to display in the modal
+   * @returns array of {@linkcode InputFieldConfig}
+   */
+  abstract getInputFieldConfigs(): InputFieldConfig[];
 
   getHeight(config?: ModalConfig): number {
-    return 20 * this.getFields().length + (this.getModalTitle() ? 26 : 0) + ((config as FormModalConfig)?.errorMessage ? 12 : 0) + this.getButtonTopMargin() + 28;
+    return 20 * this.getInputFieldConfigs().length + (this.getModalTitle() ? 26 : 0) + ((config as FormModalConfig)?.errorMessage ? 12 : 0) + this.getButtonTopMargin() + 28;
   }
 
   getReadableErrorMessage(error: string): string {
@@ -66,7 +68,7 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
     this.modalContainer.add(this.errorMessage);
   }
 
-  updateFields(fieldsConfig: InputFieldConfigs[], hasTitle: boolean) {
+  updateFields(fieldsConfig: InputFieldConfig[], hasTitle: boolean) {
     this.inputContainers = [];
     this.inputs = [];
     this.formLabels = [];
@@ -169,7 +171,7 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
   }
 }
 
-export interface InputFieldConfigs {
+export interface InputFieldConfig {
   label: string,
   isPassword?: boolean,
   isReadOnly?: boolean

--- a/src/ui/login-form-ui-handler.ts
+++ b/src/ui/login-form-ui-handler.ts
@@ -1,4 +1,4 @@
-import { FormModalUiHandler, InputFieldConfigs } from "./form-modal-ui-handler";
+import { FormModalUiHandler, InputFieldConfig } from "./form-modal-ui-handler";
 import { ModalConfig } from "./modal-ui-handler";
 import * as Utils from "../utils";
 import { Mode } from "./ui";
@@ -75,10 +75,6 @@ export default class LoginFormUiHandler extends FormModalUiHandler {
     return i18next.t("menu:login");
   }
 
-  override getFields(_config?: ModalConfig): string[] {
-    return [ i18next.t("menu:username"), i18next.t("menu:password") ];
-  }
-
   override getWidth(_config?: ModalConfig): number {
     return 160;
   }
@@ -114,15 +110,10 @@ export default class LoginFormUiHandler extends FormModalUiHandler {
     return super.getReadableErrorMessage(error);
   }
 
-  override getInputFieldConfigs(): InputFieldConfigs[] {
-    const inputFieldConfigs: InputFieldConfigs[] = [];
-    const fields = this.getFields();
-    fields.forEach((field, i) => {
-      inputFieldConfigs.push({
-        label: field,
-        isPassword: field.includes(i18next.t("menu:password")) || field.includes(i18next.t("menu:confirmPassword"))
-      });
-    });
+  override getInputFieldConfigs(): InputFieldConfig[] {
+    const inputFieldConfigs: InputFieldConfig[] = [];
+    inputFieldConfigs.push({ label: i18next.t("menu:username") });
+    inputFieldConfigs.push({ label: i18next.t("menu:password"), isPassword: true });
     return inputFieldConfigs;
   }
 

--- a/src/ui/registration-form-ui-handler.ts
+++ b/src/ui/registration-form-ui-handler.ts
@@ -1,4 +1,4 @@
-import { FormModalUiHandler, InputFieldConfigs } from "./form-modal-ui-handler";
+import { FormModalUiHandler, InputFieldConfig } from "./form-modal-ui-handler";
 import { ModalConfig } from "./modal-ui-handler";
 import * as Utils from "../utils";
 import { Mode } from "./ui";
@@ -22,10 +22,6 @@ const languageSettings: { [key: string]: LanguageSetting } = {
 export default class RegistrationFormUiHandler extends FormModalUiHandler {
   getModalTitle(config?: ModalConfig): string {
     return i18next.t("menu:register");
-  }
-
-  getFields(config?: ModalConfig): string[] {
-    return [ i18next.t("menu:username"), i18next.t("menu:password"), i18next.t("menu:confirmPassword") ];
   }
 
   getWidth(config?: ModalConfig): number {
@@ -61,15 +57,11 @@ export default class RegistrationFormUiHandler extends FormModalUiHandler {
     return super.getReadableErrorMessage(error);
   }
 
-  override getInputFieldConfigs(): InputFieldConfigs[] {
-    const inputFieldConfigs: InputFieldConfigs[] = [];
-    const fields = this.getFields();
-    fields.forEach((field, i) => {
-      inputFieldConfigs.push({
-        label: field,
-        isPassword: field.includes(i18next.t("menu:password")) || field.includes(i18next.t("menu:confirmPassword"))
-      });
-    });
+  override getInputFieldConfigs(): InputFieldConfig[] {
+    const inputFieldConfigs: InputFieldConfig[] = [];
+    inputFieldConfigs.push({ label: i18next.t("menu:username") });
+    inputFieldConfigs.push({ label: i18next.t("menu:password"), isPassword: true });
+    inputFieldConfigs.push({ label: i18next.t("menu:confirmPassword"), isPassword: true });
     return inputFieldConfigs;
   }
 

--- a/src/ui/rename-form-ui-handler.ts
+++ b/src/ui/rename-form-ui-handler.ts
@@ -1,4 +1,4 @@
-import { FormModalUiHandler, InputFieldConfigs } from "./form-modal-ui-handler";
+import { FormModalUiHandler, InputFieldConfig } from "./form-modal-ui-handler";
 import { ModalConfig } from "./modal-ui-handler";
 import i18next from "i18next";
 import { PlayerPokemon } from "#app/field/pokemon";
@@ -6,10 +6,6 @@ import { PlayerPokemon } from "#app/field/pokemon";
 export default class RenameFormUiHandler extends FormModalUiHandler {
   getModalTitle(config?: ModalConfig): string {
     return i18next.t("menu:renamePokemon");
-  }
-
-  getFields(config?: ModalConfig): string[] {
-    return [ i18next.t("menu:nickname") ];
   }
 
   getWidth(config?: ModalConfig): number {
@@ -33,15 +29,8 @@ export default class RenameFormUiHandler extends FormModalUiHandler {
     return super.getReadableErrorMessage(error);
   }
 
-  override getInputFieldConfigs(): InputFieldConfigs[] {
-    const inputFieldConfigs: InputFieldConfigs[] = [];
-    const fields = this.getFields();
-    fields.forEach((field, i) => {
-      inputFieldConfigs.push({
-        label: field
-      });
-    });
-    return inputFieldConfigs;
+  override getInputFieldConfigs(): InputFieldConfig[] {
+    return [{ label: i18next.t("menu:nickname") }];
   }
 
   show(args: any[]): boolean {

--- a/src/ui/test-dialogue-ui-handler.ts
+++ b/src/ui/test-dialogue-ui-handler.ts
@@ -1,4 +1,4 @@
-import { FormModalUiHandler, InputFieldConfigs } from "./form-modal-ui-handler";
+import { FormModalUiHandler, InputFieldConfig } from "./form-modal-ui-handler";
 import { ModalConfig } from "./modal-ui-handler";
 import i18next from "i18next";
 import { PlayerPokemon } from "#app/field/pokemon";
@@ -43,10 +43,6 @@ export default class TestDialogueUiHandler extends FormModalUiHandler {
     return "Test Dialogue";
   }
 
-  getFields(config?: ModalConfig): string[] {
-    return [ "Dialogue" ];
-  }
-
   getWidth(config?: ModalConfig): number {
     return 300;
   }
@@ -68,15 +64,8 @@ export default class TestDialogueUiHandler extends FormModalUiHandler {
     return super.getReadableErrorMessage(error);
   }
 
-  override getInputFieldConfigs(): InputFieldConfigs[] {
-    const inputFieldConfigs: InputFieldConfigs[] = [];
-    const fields = this.getFields();
-    fields.forEach((field, i) => {
-      inputFieldConfigs.push({
-        label: field
-      });
-    });
-    return inputFieldConfigs;
+  override getInputFieldConfigs(): InputFieldConfig[] {
+    return [{ label: "Dialogue" }];
   }
 
   show(args: any[]): boolean {


### PR DESCRIPTION
Removes `getFields` as it can be replaced by `getInputFieldConfigs`
and a few minor fixes:
- doc for `getInputFieldConfigs` + remove `args` since it's only used by the admin panel, which can just access the value without it needing to be an argument
- fix buzz sound playing when it shouldn't
- renamed interface `InputFieldConfigs` to `InputFieldConfig`
- remove export from `AdminSearchInfo` interface since it doesn't need to be exposed to other parts of the code

i think that's it